### PR TITLE
Allow package to use a non int PK field without code changes

### DIFF
--- a/starlette_auth/backends.py
+++ b/starlette_auth/backends.py
@@ -12,7 +12,10 @@ class ModelAuthBackend(AuthenticationBackend):
     def get_user(self, conn: HTTPConnection):
         user_id = conn.session.get("user")
         if user_id:
-            return User.query.get(user_id)
+            try:
+                return User.query.get(user_id)
+            except:
+                conn.session.pop("user")
 
     async def authenticate(self, conn: HTTPConnection):
         user = self.get_user(conn)

--- a/starlette_auth/endpoints.py
+++ b/starlette_auth/endpoints.py
@@ -74,7 +74,7 @@ class Login(HTTPEndpoint):
         try:
             user = User.query.filter(User.email == form.email.data.lower()).one()
             if user.check_password(form.password.data):
-                request.session["user"] = user.id
+                request.session["user"] = str(user.id)
                 user.last_login = datetime.utcnow()
                 user.save()
                 return RedirectResponse(

--- a/starlette_auth/tables.py
+++ b/starlette_auth/tables.py
@@ -10,8 +10,8 @@ from starlette_core.database import Base
 user_scopes = sa.Table(
     "userscope",
     Base.metadata,
-    sa.Column("user_id", sa.Integer, sa.ForeignKey("user.id")),
-    sa.Column("scope_id", sa.Integer, sa.ForeignKey("scope.id")),
+    sa.Column("user_id", Base.id.type, sa.ForeignKey("user.id"), primary_key=True),
+    sa.Column("scope_id", Base.id.type, sa.ForeignKey("scope.id"), primary_key=True),
 )
 
 


### PR DESCRIPTION
PK's can be changed to uuid by setting the Base class in the starlette_core package
before any tables are imported into your project.

The below example sets all auth models pk to a postgres specific uuid field.

```python
import sqlalchemy as sa
from sqlalchemy.dialects.postgresql import UUID
from starlette_core.database import Base, Database

from app import settings

# setup the database
db = Database(settings.DATABASE_URL)

# The following will need to be added to your first revision to enable the
# uuid extension. Using this will mean packages that interact with the db
# will not need to worry about setting a default uuid. I have seen cases where
# default=uuid.uuid4 does not work
# op.execute("create EXTENSION if not EXISTS \"uuid-ossp\"")

# change the id pk's to a postgres uuid type
Base.id = sa.Column(
    UUID(as_uuid=True), primary_key=True, server_default=sa.text("uuid_generate_v4()")
)

# import project and external tables
from starlette_auth import tables  # noqa isort:skip
```